### PR TITLE
Test on multiple architectures on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: perl
+dist: bionic
 arch:
   - amd64
   - arm64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: perl
+arch:
+  - amd64
+  - arm64
+  - ppc64le
+  - s390x
 env:
   - PERL5LIB=/home/travis/perl5
 perl:


### PR DESCRIPTION
Travis can test multiple architectures, which is particularly valuable since this module has C code that needs to demonstrate portability.

