### PR TITLE
Introduce benchmarks.sh

### DIFF
--- a/extra/benchmark.sh
+++ b/extra/benchmark.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Compare real-time parsing speeds between multiple Perl modules providing the
+# `Mac::PropertyList::parse_plist_file` interface.
+
+# Fail earl and loudly.
+set -o errexit -o nounset -o pipefail
+
+plists=( "$@" )
+
+modules=(
+    Mac::PropertyList
+    Mac::PropertyList::SAX
+    Mac::PropertyList::XS
+)
+
+real_seconds () { command time -p "$@" 2>&1 >/dev/null | grep ^real | (read _ x; echo $x); }
+
+echo -e "plist\tbytes\tmodule\tseconds"
+for p in "${plists[@]}"
+do
+    bytes=$(stat -f %z "$p")
+    for mod in "${modules[@]}"
+    do
+        echo -ne "$p\t$bytes\t$mod\t"
+        real_seconds perl -Mlib=lib -Mlib=$(realpath blib/lib),$(realpath blib/arch) -M$mod=parse_plist_file -e 'parse_plist_file(@ARGV)' "$p"
+    done
+done


### PR DESCRIPTION
See https://github.com/kulp/Mac-PropertyList-SAX/pull/9.

Speedup on a particular 2MiB file is about 3.5x over `Mac::PropertyList::SAX`, and about 25x over `Mac::PropertyList`.

```
$ ./extra/benchmark.sh /System/Library/AssetsV2/com_apple_MobileAsset_*/*/AssetData/**/*.plist | tee raw | sort -grk2 | head -n3 | column -s$'\t' -t | tee columns
/System/Library/AssetsV2/com_apple_MobileAsset_MacSoftwareUpdate/2766126fea7d22f95f86a2064d05838a8724587b.asset/AssetData/boot/BuildManifest.plist  2210128  Mac::PropertyList::XS   0.24
/System/Library/AssetsV2/com_apple_MobileAsset_MacSoftwareUpdate/2766126fea7d22f95f86a2064d05838a8724587b.asset/AssetData/boot/BuildManifest.plist  2210128  Mac::PropertyList::SAX  0.88
/System/Library/AssetsV2/com_apple_MobileAsset_MacSoftwareUpdate/2766126fea7d22f95f86a2064d05838a8724587b.asset/AssetData/boot/BuildManifest.plist  2210128  Mac::PropertyList       6.02
```